### PR TITLE
TRANSLATIONS should not be changed

### DIFF
--- a/app/controllers/memverses_controller.rb
+++ b/app/controllers/memverses_controller.rb
@@ -594,8 +594,9 @@ class MemversesController < ApplicationController
     @sub = "addvs"
     add_breadcrumb I18n.t("home_menu.Add Verse"), :add_verse_path
 
-    @translation = current_user.translation? ? current_user.translation : "NIV" # fallback on NIV
-    TRANSLATIONS[:selected] = @translation # used for jEditable
+    @translation  = current_user.translation? ? current_user.translation : "NIV" # fallback on NIV
+    @translations = TRANSLATIONS.dup
+    @translations[:selected] = @translation # used for jEditable
   end
 
   # ----------------------------------------------------------------------------------------------------------

--- a/app/views/memverses/add_verse.html.erb
+++ b/app/views/memverses/add_verse.html.erb
@@ -75,7 +75,7 @@
 			return(settings.data[value]);
 			// TODO: Can't figure out why after changing the version and clicking on the select again, it sometimes still defaults to the original 'selected' value
 		}, {
-			data   : <%= TRANSLATIONS.to_json.html_safe %>,
+			data   : <%= @translations.to_json.html_safe %>,
 			type   : 'select',
 			submit : 'OK'
 		});


### PR DESCRIPTION
I was just checking the update_profile page and saw "KJV" at the bottom of the translations list. I thought it was odd and that maybe I had made a mistake with recent translations change. Couldn't figure it out. Then saw it had become "ESV" and realized the culprit must be [this](https://github.com/avitus/Memverse/blob/master/app/controllers/memverses_controller.rb#L598). I will work to fix this.

I think something like

```
@translations = TRANSLATIONS.dup
@translations[:selected] = @translation
```

and then referencing `@translations` instead of `TRANSLATIONS` in the view should work.
