### PR TITLE
Fix admin/user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,6 +99,12 @@ class User < ActiveRecord::Base
                   :mnemonic_use, :all_refs, :referred_by, :auto_work_load, :show_email,
                   :provider, :uid
 
+  rails_admin do
+    include_all_fields
+
+    exclude_fields :church # still have church_id; fixes issue #212
+  end
+
   # ----------------------------------------------------------------------------------------------------------
   # Single Sign On support
   # ----------------------------------------------------------------------------------------------------------

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -13,13 +13,6 @@ RailsAdmin.config do |config|
 
   config.current_user_method { current_user } #auto-generated
 
-  config.model 'User' do
-    list do
-      include_all_fields
-      exclude_fields :church # still have church_id; for church problem, see #212
-    end
-  end
-
   #  ==> Authentication (before_filter)
   # This is run inside the controller instance so you can setup any authentication you need to.
   # By default, the authentication will run via warden if available.


### PR DESCRIPTION
Can't update user. See [this](https://veetle.airbrake.io/projects/16073/groups/70539166/notices/1095605517096807993).

Error Message:

```
ActiveRecord::AssociationTypeMismatch: Church(#70302424960560) expected, got String(#70302379183180)
```

Where:

```
rails_admin/main#edit
[GEM_ROOT]/gems/activerecord-4.0.2/lib/active_record/associations/association.rb, line 224
```

Hmm... I didn't realize we have both `church` and `church_id` fields on the User. `church` seems to be a cached name for the church in `church_id`. RailsAdmin is expecting the `user[church]` field to be related to the Church model. We need a way to prevent RailsAdmin from touching the `church` string.

For reference: [RailsAdmin DSL](https://github.com/sferik/rails_admin/wiki/Railsadmin-DSL).
