### PR TITLE
Add Authorized KJV and Scottish Metrical Psalter

### DIFF
--- a/app/views/home/quick_start.html.erb
+++ b/app/views/home/quick_start.html.erb
@@ -36,8 +36,10 @@
 					<%= trans_set_link("AMP",   "Amplified Bible") %>
 					<%= trans_set_link("IRV",   "New Intl Reader's Ver") %>
 					<%= trans_set_link("NCV",   "New Century Version") %>
+					<%= trans_set_link("AKJ",   "Authorized King James Ver") %>
 					<%= trans_set_link("UKJ",   "Updated King James Ver") %>
 					<%= trans_set_link("GEN",   "Geneva Bible") %>
+					<%= trans_set_link("SMP",   "Scottish Metrical Psalter") %>
 					<li id="global-tl">         <%= link_to 'Show other languages',               nil, :class => 'active',     :remote => true %></li>
 					<li class="tl-root">        <%= link_to '« Back',                             nil, :class => 'active',     :remote => true %></li>
 				</ul>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -47,7 +47,9 @@ TRANSLATIONS = {
     :HCV   => "Haitian Creole Version",
     :NBLH  => "Nueva Biblia Latinoamericana de Hoy",
     :LBLA  => "La Biblia de las Américas",
-    :ICE   => "Icelandic Bible (2007)"
+    :ICE   => "Icelandic Bible (2007)",
+    :SMP   => "Scottish Metrical Psalter",
+    :AKJ   => "Authorized King James Version"
   }
 
 MAJORS = {


### PR DESCRIPTION
@avitus As long as the abbreviations and names look good, this should be fine (for #253). At first I started calling the AUthorized KJV "AKJV" but then realized it should be "AKJ" based on our existing conventions.
