### PR TITLE
Triage dependency backlog; sync docs to Rails 7.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Architecture Overview
 
-This is a Ruby on Rails 7.1 Bible memorization application with a traditional MVC architecture.
+This is a Ruby on Rails 7.2 Bible memorization application with a traditional MVC architecture.
 
 ### Core Models & Domain
 - **User**: Central model managing authentication, preferences, and Bible translation settings
@@ -221,7 +221,7 @@ This is a Ruby on Rails 7.1 Bible memorization application with a traditional MV
 | Component | Previous Version | Current Version | Status |
 |-----------|-----------------|-----------------|---------|
 | Ruby | 2.7.8 | 3.2.6 | ✅ Complete |
-| Rails | 5.2.8.1 | 7.1.5.2 | ✅ Complete |
+| Rails | 5.2.8.1 | 7.2.3.1 | ✅ Complete |
 | File Storage | Paperclip | Active Storage | ✅ Complete |
 | JavaScript Testing | Jasmine | Vitest | ✅ Complete |
 | API Framework | RocketPants | Rails API | ✅ Complete |
@@ -304,6 +304,16 @@ touch tmp/restart.txt
 - RSpec: 474/474 passing (100%)
 - Vitest: 69/69 passing (100%)
 - Cucumber: All features pass individually (100%)
+
+### ✅ Rails 7.2 Upgrade (COMPLETED - 2026)
+**Progression**: Rails 7.1.5.2 → 7.2.3.1
+
+**Key Changes**:
+- Upgraded the Rails gem from 7.1.5.2 to 7.2.3.1
+- Adopted Rails 7.2 framework defaults (config.load_defaults 7.2)
+- Addressed DeepSource and CodeRabbit review comments; added CodeRabbit config
+- See `documentation/plans/2026-06-26-rails-7.2-upgrade.md` and
+  `documentation/specs/2026-06-26-rails-7.2-upgrade-design.md`
 
 ### ✅ User Onboarding Email Optimization (COMPLETED - September 2025)
 **Objective**: Reduce Gmail rate limiting by consolidating onboarding emails

--- a/documentation/MODERNIZATION_PLAN.md
+++ b/documentation/MODERNIZATION_PLAN.md
@@ -26,10 +26,10 @@ This document tracks the technical modernization progress of the Memverse applic
 
 ### ✅ Framework & Language Upgrades (COMPLETED - August 2025)
 - [x] Upgrade Ruby from 2.7.8 to 3.2.6 (current stable)
-- [x] Upgrade Rails from 5.2.8.1 to 7.1.5.2 (latest stable)
+- [x] Upgrade Rails from 5.2.8.1 to 7.2.3.1 (latest stable)
 - [x] Update all gems to Rails 7 compatible versions
 - [x] Remove deprecated gems (rails-observers, protected_attributes references)
-- [x] Apply Rails 7.1 configuration defaults (config.load_defaults 7.1)
+- [x] Apply Rails 7.2 configuration defaults (config.load_defaults 7.2)
 - [x] Create ApplicationRecord base class for all models
 - [x] Add bootsnap for improved boot performance
 - [x] Add Ruby 3.2 standard library gems (net-http, rss)
@@ -81,6 +81,18 @@ This document tracks the technical modernization progress of the Memverse applic
 - [x] Update acts-as-taggable-on to v10.0 (Rails 7 compatible)
 - [x] Update PubNub to v5.5.0 (latest stable)
 - [x] Update RPush to v9.2.0 (Rails 7.1 compatible)
+
+### 🔒 Blocked Dependency Bumps (transitive version pins)
+These Dependabot proposals **cannot be applied** without first upgrading the gem
+that pins them. Documented here so they aren't repeatedly re-triaged:
+- **jwt → 3.x** — blocked. `googleauth`, `signet`, and `web-push` all require
+  `jwt < 3.0`. Requires coordinated upgrade of those gems first.
+- **addressable → 2.9.0** — blocked. `onebox (~> 2.8.0)` caps it at `< 2.9.0`.
+  Requires upgrading `onebox` (Discourse link-preview gem used by Thredded) first.
+
+All other Dependabot bumps (bcrypt, devise, sidekiq-cron, rack, faraday, nokogiri,
+net-imap, erb, vite, picomatch, flatted) were already satisfied by the
+`patch-independent-gems` work — the lockfiles are at or above the proposed versions.
 
 ## ⚠️ In Progress / Partially Completed
 
@@ -168,7 +180,7 @@ This document tracks the technical modernization progress of the Memverse applic
 ### Overall Progress: ~55% Complete
 
 The Memverse application has successfully completed critical modernization milestones:
-- ✅ Ruby 3.2.6 and Rails 7.1.5.2 upgrades
+- ✅ Ruby 3.2.6 and Rails 7.2.3.1 upgrades
 - ✅ Security vulnerabilities fixed
 - ✅ Core infrastructure modernized (email, file storage, background jobs)
 - ✅ 100% test coverage maintained


### PR DESCRIPTION
## Summary
Closes out the Dependabot backlog and refreshes stale docs. **Docs-only — no code or lockfile change.**

### Dependabot backlog: 13 → 0
Every open Dependabot PR (#372–#384) was cross-checked against the installed lockfiles and closed with an explanation:

- **11 already satisfied/exceeded** by the earlier `patch-independent-gems` work (bcrypt, devise, sidekiq-cron, rack, faraday, nokogiri, net-imap, erb, vite, picomatch, flatted) — lockfiles are at or above the proposed versions.
- **2 blocked by transitive pins** (documented so they don't get re-triaged):
  - `jwt 3.x` — capped `< 3.0` by `googleauth`, `signet`, `web-push`.
  - `addressable 2.9.0` — capped `< 2.9.0` by `onebox (~> 2.8.0)`.

### Doc updates
- `CLAUDE.md` + `MODERNIZATION_PLAN.md`: Rails `7.1.5.2 → 7.2.3.1`, `load_defaults 7.2`, added a Rails 7.2 upgrade note.
- `MODERNIZATION_PLAN.md`: new **Blocked Dependency Bumps** section recording the jwt/addressable constraints.

## Testing
Not run — this PR changes only Markdown docs; no Ruby/JS/lockfile changes, so the suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to reflect the upgrade to Rails 7.2.3.1.
  * Revised the modernization plan to show the current Rails defaults and overall progress accurately.
  * Added notes about upgrade blockers for a few dependency updates so the status is clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->