### PR TITLE
Pin openssl gem to ~> 3.3.0 to unblock production deploys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,7 @@ gem "sentry-sidekiq"                                                           #
 ############################################################
 gem 'pubnub', '~> 5.5.0'                                                      # Real-time messaging service - updated to latest
 gem 'rpush', '~> 9.2.0'                                                        # Push notification service - Rails 7.1 compatible
+gem 'openssl', '~> 3.3.0'                                                      # web-push dependency; 4.x needs OpenSSL >= 1.1.1, prod (Ubuntu 16.04) has 1.0.2g
 gem 'mail', '>= 2.2.15'                                                        # Emails
 gem 'postmark-rails', '~> 0.22'                                                # Postmark email delivery service
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,7 +474,7 @@ GEM
       mustache
       nokogiri (~> 1.7)
       sanitize
-    openssl (4.0.2)
+    openssl (3.3.3)
     orm_adapter (0.5.0)
     os (1.1.4)
     ostruct (0.6.3)
@@ -849,6 +849,7 @@ DEPENDENCIES
   newrelic_rpm (>= 3.3.0)
   nokogiri (>= 1.5.0)
   omniauth
+  openssl (~> 3.3.0)
   postmark-rails (~> 0.22)
   prawn
   prawnto_2


### PR DESCRIPTION
## Problem

`cap production deploy` failed during `bundle install`:

```
extconf.rb:126:in `<main>': OpenSSL >= 1.1.1 or LibreSSL >= 3.9.0 is required (RuntimeError)
An error occurred while installing openssl (4.0.2), and Bundler cannot continue.
```

## Root cause

The jwt 3.x upgrade (c9f7735d) bumped `web-push` 3.0.1 → 3.1.0, whose openssl constraint loosened from `~> 3.0` to `>= 3.0`, letting the lockfile jump the `openssl` gem from 3.3.0 to 4.0.2. The openssl gem 4.x dropped support for OpenSSL 1.0.2–1.1.0, and production runs Ubuntu 16.04 with system OpenSSL 1.0.2g (Ruby 3.2.6 is linked against it), so the native extension can never compile there. This was the first deploy that needed to compile the openssl gem at all.

## Fix

Pin `gem 'openssl', '~> 3.3.0'` — the 3.3 series is the newest that still builds against OpenSSL 1.0.2. Only `web-push` depends on the openssl gem and it accepts `>= 3.0`, so the lockfile diff is exactly one gem: openssl 4.0.2 → 3.3.3.

## Verification

- Test-compiled openssl 3.3.3 on the production server (isolated to /tmp, cleaned up): builds cleanly against 1.0.2g
- RSpec: 1233 examples, 0 failures, 25 pending
- Vitest: 409/409 passed
- Cucumber: 72/72 scenarios, 559/559 steps passed

## Note

This is a stopgap. Ubuntu 16.04 and OpenSSL 1.0.2 are both years past EOL; more gems will raise their OpenSSL floor over time. The durable fix is migrating production to a modern distro with Ruby rebuilt against a current OpenSSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying platform support for improved compatibility with web-based notifications.
  * No changes to the user interface or existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->