### PR TITLE
Fix voice review status overlap and add Review menu link

### DIFF
--- a/app/assets/stylesheets/mv_voice_practice.scss
+++ b/app/assets/stylesheets/mv_voice_practice.scss
@@ -41,6 +41,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
+
   // Absolutely positioned over .voice-header, so long status messages
   // (e.g. "Speech recognition not supported...") must wrap within the
   // left gutter instead of extending under the centered verse reference

--- a/app/assets/stylesheets/mv_voice_practice.scss
+++ b/app/assets/stylesheets/mv_voice_practice.scss
@@ -41,6 +41,10 @@
   display: flex;
   align-items: center;
   gap: 12px;
+  // Absolutely positioned over .voice-header, so long status messages
+  // (e.g. "Speech recognition not supported...") must wrap within the
+  // left gutter instead of extending under the centered verse reference
+  max-width: 25%;
 }
 
 .mic-button {
@@ -103,7 +107,15 @@
 .mic-status {
   color: #6b9620;
   font-size: 0.95em;
-  white-space: nowrap;
+}
+
+// When speech recognition is unavailable (e.g. Firefox), the mic is dead
+// anyway — show the controls as a normal full-width row under the header
+// so the long status message can't collide with the verse reference
+.voice-practice.speech-unsupported .voice-controls {
+  position: static;
+  max-width: none;
+  margin-bottom: 15px;
 }
 
 .voice-transcription-wrapper {

--- a/app/controllers/memverses_controller.rb
+++ b/app/controllers/memverses_controller.rb
@@ -1335,7 +1335,7 @@ class MemversesController < ApplicationController
   # Voice practice - speak verses using Web Speech API
   # ----------------------------------------------------------------------------------------------------------
   def voice_practice
-    @tab = "learn"
+    @tab = "mem"
     @sub = "voice"
 
     # Check if user has any verses at all

--- a/app/views/layouts/_top_nav.html.erb
+++ b/app/views/layouts/_top_nav.html.erb
@@ -45,6 +45,7 @@
                     <li <%= sub(@sub=="acctest"     )%>><%= link_to t('memorize_menu.Accuracy Test'),   main_app.test_accuracy_path %></li>
                     <li <%= sub(@sub=="passrev"     )%>><%= link_to t('memorize_menu.Passage Review'),  main_app.passage_review_path %></li>
                     <li <%= sub(@sub=="chrev"       )%>><%= link_to t('memorize_menu.Chapter Review'),  main_app.pre_chapter_path %></li>
+                    <li <%= sub(@sub=="voice"       )%>><%= link_to t('memorize_menu.Voice Review'),    main_app.voice_review_path %></li>
                 </ul>
             </div>
 

--- a/app/views/memverses/voice_practice.html.erb
+++ b/app/views/memverses/voice_practice.html.erb
@@ -767,6 +767,9 @@ $(document).ready(function() {
   var SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
 
   if (!SpeechRecognition) {
+    // Full-width notice row (see .speech-unsupported) so the long message
+    // doesn't collide with the verse reference (e.g. in Firefox)
+    $('.voice-practice').addClass('speech-unsupported');
     $('#mic-button').prop('disabled', true);
     $('#mic-status').text('Speech recognition not supported in this browser. Please use Chrome or Edge.');
   } else {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,7 @@ en:
     "Accuracy Test": "Accuracy Test"
     "Chapter Review": "Chapter Review"
     "Passage Review": "Passage Review"
+    "Voice Review": "Voice Review"
     
   leader_menu:
     Leaderboard: "Leaderboard"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -287,6 +287,7 @@
     Accuracy Test:         "Exactitud de la prueba"
     Passage Review:        "Revisión del pasaje"
     Chapter Review:        "Revisión del capítulo"
+    Voice Review:          "Revisión por voz"
   learn_menu:
     Learn:                 "Aprender"
     Practice:              "Práctica"

--- a/config/locales/in.yml
+++ b/config/locales/in.yml
@@ -274,6 +274,7 @@
     Accuracy Test:         "Tes Akurasi"
     Passage Review:        "Bagian Ulasan"
     Chapter Review:        "Bab Review"
+    Voice Review:          "Ulasan Suara"
   learn_menu:
     Learn:                 "Belajar"
     Practice:              "Praktek"

--- a/features/memverses/voice_review_nav.feature
+++ b/features/memverses/voice_review_nav.feature
@@ -1,0 +1,14 @@
+Feature: Voice Review navigation
+  In order to review verses by speaking them
+  A user
+  Should be able to reach Voice Review from the Review menu
+
+  Scenario: Review submenu links to Voice Review
+    Given I sign in as a normal user
+    When I go to the home page
+    Then the Review submenu should contain a "Voice Review" link to "/voice_review"
+
+  Scenario: Voice Review link routes to the voice review page
+    Given I sign in as a normal user
+    When I follow "Voice Review"
+    Then I should see "You need to add some verses first."

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -1,0 +1,7 @@
+# Steps for the top navigation menu and its submenus
+
+Then /^the Review submenu should contain a "([^"]*)" link to "([^"]*)"$/ do |text, href|
+  within('#memory') do
+    expect(page).to have_link(text, href: href)
+  end
+end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -1,6 +1,6 @@
 # Steps for the top navigation menu and its submenus
 
-Then /^the Review submenu should contain a "([^"]*)" link to "([^"]*)"$/ do |text, href|
+Then(/^the Review submenu should contain a "([^"]*)" link to "([^"]*)"$/) do |text, href|
   within('#memory') do
     expect(page).to have_link(text, href: href)
   end

--- a/spec/controllers/memverses_controller_spec.rb
+++ b/spec/controllers/memverses_controller_spec.rb
@@ -431,6 +431,12 @@ describe MemversesController do
         get :voice_practice, session: valid_session
         expect(assigns(:mv)).to be_present
       end
+
+      it "should highlight the Review tab with the voice submenu" do
+        get :voice_practice, session: valid_session
+        expect(assigns(:tab)).to eq("mem")
+        expect(assigns(:sub)).to eq("voice")
+      end
     end
 
     context "when user has only learning verses" do


### PR DESCRIPTION
## Summary

- **Fix**: In browsers without the Web Speech API (Firefox), the "Speech recognition not supported in this browser" message overlapped the centered verse reference on the voice review page. Root cause: `.voice-controls` is absolutely positioned over the header and `#mic-status` had `white-space: nowrap`, so the long message rendered as one unwrappable line under the reference.
  - Long runtime statuses (e.g. "Microphone access denied…", which could overlap in Chrome too) now wrap within a `max-width: 25%` gutter.
  - The unsupported-browser state adds a `speech-unsupported` class that drops the controls into normal flow as a full-width notice row, so it can never collide with the reference — even with long references like "1 Corinthians 13:4-7".
- **Feature**: Adds a **Voice Review** link to the Review tab submenu (with en/es/in translations) and switches the page's `@tab` from `"learn"` to `"mem"` so the Review tab highlights correctly.

## Layout before/after (Firefox unsupported state)

Before: message ran under the verse reference. After: reference centered, notice on its own full-width row; the normal Chrome layout is unchanged. Verified with headless Chrome against the compiled application CSS.

## Test plan

- [x] New controller spec: `@tab`/`@sub` assignments (written failing-first)
- [x] New Cucumber scenarios: Voice Review link present in Review submenu; link routes to the voice review action
- [x] RSpec: 1234 examples, 0 failures (25 pending, expected)
- [x] Vitest: 409 passed
- [x] Cucumber: 74 scenarios / 565 steps, all passed

Note: the legacy generic `within` meta-step in `web_steps.rb` is broken under modern Cucumber (removed nested-`When` API); this PR adds a small dedicated step in `navigation_steps.rb` rather than repairing the unused meta-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Voice Review” option to the Review menu in English, Spanish, and Indonesian.
  * Improved navigation so Voice Review appears under the correct Review section.
* **Bug Fixes**
  * Voice Review now correctly highlights the Review menu and submenu.
  * Improved voice-control layout and status-message wrapping.
  * Unsupported speech recognition now displays a clearer, full-width control layout with appropriate spacing.
* **Tests**
  * Added coverage for Voice Review navigation and menu selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->